### PR TITLE
Change unknown clang warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ if(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
 
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Weverything \
  -Wno-c++98-compat -Wno-c++98-compat-pedantic\
- -Wno-c++98-c++11-compat-pedantic -Wno-undefined-func-template\
+ -Wno-c++98-c++11-compat-pedantic -Wno-undefined-internal\
  -Wno-exit-time-destructors -Wno-global-constructors\
  -Wno-unknown-pragmas -Wno-missing-prototypes -Wno-undef\
  -Wno-language-extension-token -Wno-missing-noreturn -Wno-missing-noreturn\


### PR DESCRIPTION
Clang does not known this warning, so it was change to something that was proposed, however maybe it should not be added
Also google refuse to tell what removed warning means

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nadzwyczajnagruparobocza/papuc_exercises/33)
<!-- Reviewable:end -->
